### PR TITLE
Added support for Minnowboard MAX

### DIFF
--- a/Adafruit_ILI9341/ILI9341.py
+++ b/Adafruit_ILI9341/ILI9341.py
@@ -27,6 +27,7 @@ import ImageDraw
 
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
+import Adafruit_GPIO.Platform as Platform
 
 
 # Constants for interacting with display registers.
@@ -138,8 +139,14 @@ class ILI9341(object):
 		# Set SPI to mode 0, MSB first.
 		spi.set_mode(0)
 		spi.set_bit_order(SPI.MSBFIRST)
-		spi.set_clock_hz(64000000)
-		# Create an image buffer.
+	
+                # Clock nerfed for the Minnowboard	
+                if(Platform.platform_detect() == 3):
+                    spi.set_clock_hz(1000000)
+                else:
+                    spi.set_clock_hz(64000000)
+		
+                # Create an image buffer.
 		self.buffer = Image.new('RGB', (width, height))
 
 	def send(self, data, is_data=True, chunk_size=4096):

--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ sudo pip install RPi.GPIO
 For a BeagleBone Black make sure you have the Adafruit_BBIO library by executing:
 
 ````
-sudo pip instal Adafruit_BBIO
+sudo pip install Adafruit_BBIO
 ````
+
+For a Minnowboard or Minnowboard MAX, make sure you have the mraa library from the [Intel Repo](https://github.com/intel-iot-devkit/mraa). The easiest install method is to use npm:
+
+```bash
+npm install mraa
+```
 
 Install the library by downloading with the download link on the right, unzipping the archive, navigating inside the library's directory and executing:
 

--- a/examples/image.py
+++ b/examples/image.py
@@ -37,8 +37,17 @@ SPI_DEVICE = 0
 # SPI_PORT = 1
 # SPI_DEVICE = 0
 
+# Minnowboard configuration
+# DC = 26
+# RST = 25
+# SPI_PORT = 0
+# SPI_DEVICE = 0
+
 # Create TFT LCD display class.
 disp = TFT.ILI9341(DC, rst=RST, spi=SPI.SpiDev(SPI_PORT, SPI_DEVICE, max_speed_hz=64000000))
+
+# Create display class under Minnowboard with mraa
+# disp = TFT.ILI9341(DC, rst=RST, spi=SPI.SpiDevMraa(SPI_PORT, SPI_DEVICE, max_speed_hz=1000000))
 
 # Initialize display.
 disp.begin()

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -39,8 +39,17 @@ SPI_DEVICE = 0
 # SPI_PORT = 1
 # SPI_DEVICE = 0
 
+# Minnowboard configuration
+# DC = 26
+# RST = 25
+# SPI_PORT = 0
+# SPI_DEVICE = 0
+
 # Create TFT LCD display class.
 disp = TFT.ILI9341(DC, rst=RST, spi=SPI.SpiDev(SPI_PORT, SPI_DEVICE, max_speed_hz=64000000))
+
+# Creation of display class under Minnowboard with mraa
+# disp = TFT.ILI9341(DC, rst=RST, spi=SPI.SpiDevMraa(SPI_PORT, SPI_DEVICE, max_speed_hz=1000000))
 
 # Initialize display.
 disp.begin()


### PR DESCRIPTION
Added support for the [Minnowboard MAX](http://www.minnowboard.org/meet-minnowboard-max/) development board. The functions have been mapped to the [mraa library](https://github.com/intel-iot-devkit/mraa) for compatibility and ease of use. The library provides platform detection and 1-to-1 mapping, although the clock speed had to be adjusted for the Minnowboard. This will go with the pull request for Minnowboard compatibility for the Adafruit Python GPIO repo. 
