### PR TITLE
Support for ILI9340 and PiTFT 2.2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Adafruit Python ILI9341 (ILI9340 compatible)
 
 Python library to control an ILI9341 (ILI9340 compatible) TFT LCD display.  Allows simple drawing on the display without installing a kernel module.
 
-Designed specifically to work with the Adafruit 2.8" LCD's ----> https://www.adafruit.com/products/1770 
+Designed specifically to work with the Adafruit 2.8" LCD's ----> https://www.adafruit.com/products/1770
+
 Additionaly work with the Adafruit 2.2" (PiTFT) LCD's ----> https://www.adafruit.com/products/2315
 
 For all platforms (Raspberry Pi and Beaglebone Black) make sure you have the following dependencies:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-Adafruit Python ILI9341
+Adafruit Python ILI9341 (ILI9340 compatible)
 =======================
 
-Python library to control an ILI9341 TFT LCD display.  Allows simple drawing on the display without installing a kernel module.
+Python library to control an ILI9341 (ILI9340 compatible) TFT LCD display.  Allows simple drawing on the display without installing a kernel module.
 
 Designed specifically to work with the Adafruit 2.8" LCD's ----> https://www.adafruit.com/products/1770 
+Additionaly work with the Adafruit 2.2" (PiTFT) LCD's ----> https://www.adafruit.com/products/2315
 
 For all platforms (Raspberry Pi and Beaglebone Black) make sure you have the following dependencies:
 

--- a/examples/image.py
+++ b/examples/image.py
@@ -24,9 +24,13 @@ import Adafruit_ILI9341 as TFT
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
 
+PITFT_2_8 = 18
+PITFT_2_2 = 25
+
+CURRENT_PITFT = PITFT_2_8
 
 # Raspberry Pi configuration.
-DC = 18
+DC = CURRENT_PITFT
 RST = 23
 SPI_PORT = 0
 SPI_DEVICE = 0

--- a/examples/image_timed.py
+++ b/examples/image_timed.py
@@ -24,9 +24,13 @@ import Adafruit_ILI9341 as TFT
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
 
+PITFT_2_8 = 18
+PITFT_2_2 = 25
+
+CURRENT_PITFT = PITFT_2_8
 
 # Raspberry Pi configuration.
-DC = 18
+DC = CURRENT_PITFT
 RST = 23
 SPI_PORT = 0
 SPI_DEVICE = 0

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -26,9 +26,13 @@ import Adafruit_ILI9341 as TFT
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
 
+PITFT_2_8 = 18
+PITFT_2_2 = 25
+
+CURRENT_PITFT = PITFT_2_8
 
 # Raspberry Pi configuration.
-DC = 18
+DC = CURRENT_PITFT
 RST = 23
 SPI_PORT = 0
 SPI_DEVICE = 0


### PR DESCRIPTION
i added a flag to switch between the 2.8" and 2.2" display
only the DC pins are different (2.2 --> GPIO25, 2.8 --> GPIO18)
the ILI9340 sequence is equal to the ILI9341
