### PR TITLE
Fixed bug with hardcoded SPI speed, not allowing change of SPI speed.

### DIFF
--- a/Adafruit_ILI9341/ILI9341.py
+++ b/Adafruit_ILI9341/ILI9341.py
@@ -138,7 +138,6 @@ class ILI9341(object):
         # Set SPI to mode 0, MSB first.
         spi.set_mode(0)
         spi.set_bit_order(SPI.MSBFIRST)
-        spi.set_clock_hz(64000000)
         # Create an image buffer.
         self.buffer = Image.new('RGB', (width, height))
 


### PR DESCRIPTION
Using the Adafruit Python ILI9341 library I found that under the example code found in https://github.com/adafruit/Adafruit_Python_ILI9341/blob/master/examples/image.py

The max_speed_hz of SpiDev does not work. Confirmed my conclusion with a logic analyzer and saw that change in max_speed_hz does not affect the spi speed which stays flat at 65Mhz. 
After short investigation, I found the problem is in the ILI9341 library under the ILI9341 class where the max_speed_hz was hardcoded. 
Anyways, the API does not mention hardcoded value and during my tests I did not found problems with running the displays on different speeds. Therefore this is a bug which was fixed by removing a single line in the code. 

Hope this info is useful .
